### PR TITLE
Fix templates compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ Docker jenkins:
   script:
     - molecule test -s default
   tags:
-    - docker
+    - aws
 
 AWS jenkins:
   variables:

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -12,3 +12,8 @@ def test_hosts_file(host):
     assert f.exists
     assert f.user == 'root'
     assert f.group == 'root'
+
+
+def test_jenkins(host):
+    assert host.service('jenkins').is_running
+    assert host.socket("tcp://0.0.0.0:8080").is_listening

--- a/templates/set-credentials.groovy.j2
+++ b/templates/set-credentials.groovy.j2
@@ -12,7 +12,7 @@ import com.cloudbees.jenkins.plugins.awscredentials.*
 domain = Domain.global()
 store = Jenkins.instance.getExtensionList('com.cloudbees.plugins.credentials.SystemCredentialsProvider')[0].getStore()
 
-{% for key, value in jenkins2_credentials.iteritems() -%}
+{% for key, value in jenkins2_credentials.items() -%}
 {% set name, properties = key, value -%}
 {% if properties.type == 'gitlabtoken' %}
 	token = new Secret("{{ properties.token }}")

--- a/templates/set-ec2_configuration.groovy.j2
+++ b/templates/set-ec2_configuration.groovy.j2
@@ -12,7 +12,7 @@ import jenkins.model.Jenkins
 
 {% set slaveTemplateList = [] %}
 
-{% for key, value in jenkins2_ec2_ami_list.iteritems() -%}
+{% for key, value in jenkins2_ec2_ami_list.items() -%}
 
   {% set TagList = [] %}
 


### PR DESCRIPTION
Make templates set-credentials.groovy.j2 and set-ec2_configuration.groovy.j2 compatible with Python 2 and 3