### PR TITLE
Added lock_timeout

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: "Jenkins installation and configuration"
   company: "Epam Systems"
   license: "Apache"
-  min_ansible_version: "2.5"
+  min_ansible_version: "2.8"
   issue_tracker_url: "https://github.com/lean-delivery/ansible-role-jenkins/issues"
   platforms:
     - name: "Ubuntu"

--- a/tasks/system/RedHat.yml
+++ b/tasks/system/RedHat.yml
@@ -10,9 +10,11 @@
       yum:
         name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
         state: "present"
+        lock_timeout: 180
 
     - name: "Install requirements"
       package:
         name: "{{ requirements }}"
         state: "present"
+        lock_timeout: 180
   become: True


### PR DESCRIPTION
Added the parameter lock_timeout.
lock_timeout has been set 180, the amount of time to wait for the yum lockfile to be freed.
Since lock_timeout has been added in Ansible 2.8, therefore the parameter min_ansible_version also changed to "2.8".