### PR TITLE
Plugins version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Jenkins 2 installation
 ## Summary
 
 This role:
-  - installs jenkins2 on Ununtu, Centos7, RHEL7
+  - installs jenkins2 on Ubuntu, Centos7, RHEL7
   - make minimal configuration (e.g. smtp config, plugins install)
 
 Role tasks
@@ -183,6 +183,11 @@ Requirements
      default: `2000`
   - `jenkins2_plugins_list` - list of plugins (will be merged with suggested list)   
      default: `[]`
+  - `jenkins2_plugins_version` - Enable to specifie version numbers. All plugin dependencies must be provided in jenkins2_plugins_dict.   
+     default: `false`
+  - `jenkins2_plugins_dict` - dict of plugins used instead of lists if version enabled. Quote the version to prevent the value to be interpreted as float. Example: `ssh-slaves: '1.30.0'`
+     default: `{}`
+jenkins2_plugins_version: false
 # credentials configuration
   - `jenkins2_credentials_enabled` - to add credentials   
      default: `true`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,6 +78,7 @@ jenkins2_smtp_port: '587'
 jenkins2_smtp_host: 'smtp.office365.com'
 # Plugin installation
 jenkins2_plugins_timeout: 2000
+jenkins2_plugins_version: false
 jenkins2_plugins_suggested:
   - ant
   - antisamy-markup-formatter
@@ -116,6 +117,7 @@ jenkins2_plugins_suggested:
   - active-directory
   - permissive-script-security
 jenkins2_plugins_list: []
+jenkins2_plugins_dict: {}
 
 # Set Credentials
 jenkins2_credentials_enabled: true

--- a/tasks/install_plugins.yml
+++ b/tasks/install_plugins.yml
@@ -22,17 +22,20 @@
     url: 'http://localhost:{{ jenkins2_config_http_port }}'
     url_username: '{{ jenkins2_cli_username }}'
     url_password: '{{ jenkins2_cli_password }}'
-    name: '{{ item }}'
+    name: '{{ item.key | default(item) }}'
+    version: '{{ item.value | default(omit) }}'
     owner: '{{ jenkins2_user }}'
     validate_certs: false
     jenkins_home: '{{ jenkins2_home_directory }}'
     state: present
     timeout: '{{ jenkins2_plugins_timeout }}'
   register: my_jenkins_plugins
+  until: my_jenkins_plugins is succeeded
   retries: 10
   delay: 3
   with_items:
-    - '{{ (jenkins2_plugins_suggested | union(jenkins2_plugins_list)) | unique }}'
+    - '{{ (jenkins2_plugins_dict | dict2items) if jenkins2_plugins_version else
+          (jenkins2_plugins_suggested | union(jenkins2_plugins_list) | unique) }}'
   become: true
   notify:
     - Restart Jenkins


### PR DESCRIPTION
# Pull Request

## Description

New feature to install exact plugins versions to have ability of clone existent Jenkins instalation. Get plugins list with versions from http://<jenkins_host>:<port>/script by running `jenkins.model.Jenkins.instance.getPluginManager().getPlugins().stream().sorted().each { println "${it.getShortName()}: '${it.getVersion()}'" }` and provide output to `jenkins2_plugins_dict:` and set `jenkins2_plugins_version: true`. 
Note: older versions of Jenkins may have different method to get plugin list.

Fixes # Task `Install Jenkins plugins` to have retries on plugin install failure.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Reviews

Please identify developer to review this change

- [] @pavelpikta
- [] @ViachaslauKabak

## Checklist:

- [+] I have performed a self-review of my own code
- [+] I have made corresponding changes to the documentation
- [+] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [+] existing tests pass with my changes
