### PR TITLE
octal permissions to be used as a string

### DIFF
--- a/tasks/configure_ssh_keys.yml
+++ b/tasks/configure_ssh_keys.yml
@@ -4,7 +4,7 @@
   file:
     path: '{{ jenkins2_home_directory }}/.ssh'
     state: directory
-    mode: 0700
+    mode: "0700"
   become: true
 
 - name: Ensure that openssh *private* key doesn't exist
@@ -99,7 +99,7 @@
     mode: '{{ item.mode }}'
   become: true
   with_items:
-    - {dst: '{{ jenkins2_home_directory }}/.ssh', mode: 0700}
-    - {dst: '{{ jenkins2_home_directory }}/.ssh/{{ jenkins2_ssh_keys_private_keyname }}', mode: 0600}
-    - {dst: '{{ jenkins2_home_directory }}/.ssh/{{ jenkins2_ssh_keys_private_keyname }}.pub', mode: 0600}
-    - {dst: '{{ jenkins2_home_directory }}/.ssh/known_hosts', mode: 0644}
+    - {dst: '{{ jenkins2_home_directory }}/.ssh', mode: "0700"}
+    - {dst: '{{ jenkins2_home_directory }}/.ssh/{{ jenkins2_ssh_keys_private_keyname }}', mode: "0600"}
+    - {dst: '{{ jenkins2_home_directory }}/.ssh/{{ jenkins2_ssh_keys_private_keyname }}.pub', mode: "0600"}
+    - {dst: '{{ jenkins2_home_directory }}/.ssh/known_hosts', mode: "0644"}


### PR DESCRIPTION
octal permissions are quoted so it'll be used as a string to prevent "bad symbolic permission for mode"

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Reviews

Please identify developer to review this change

- [ ] @developer

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
